### PR TITLE
Impedir que o corte do nome termine com espaço

### DIFF
--- a/src/Pix.php
+++ b/src/Pix.php
@@ -85,6 +85,7 @@ class Pix {
     public static function name($name) {
         $name = \substr($name, 0, 25);
         $name = URLify::downcode($name);
+        $name = trim($name);
         $name_len_pad = self::lpad(\strlen($name));
         return "59{$name_len_pad}$name";
     }


### PR DESCRIPTION
Estou com um cenario onde o nome é cortado justamente no espaço, e quando os bancos tentam ler o qr code, diz qr code invalido, com essa alteração o problema sanado.